### PR TITLE
Add E2E screenshot email reports via AWS SES

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,86 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+env:
+  AWS_REGION: 'eu-west-1'
+  SES_SENDER: 'craig@craigmacintyre.co.uk'
+
+permissions:
+  contents: read
+
+jobs:
+  e2e:
+    name: Run E2E Tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'yarn'
+
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Run E2E tests
+        id: e2e
+        run: yarn test:e2e
+        continue-on-error: true
+
+      - name: Install SES SDK
+        if: always()
+        run: npm install --no-save @aws-sdk/client-ses
+
+      - name: Configure AWS Credentials
+        if: always()
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Send E2E report email
+        if: always()
+        run: node scripts/send-e2e-report.mjs
+        env:
+          SES_SENDER: ${{ env.SES_SENDER }}
+          SES_RECIPIENT: ${{ env.SES_SENDER }}
+          RESULTS_JSON: e2e/test-results.json
+          SCREENSHOTS_DIR: e2e/test-results
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: e2e/playwright-report/
+          retention-days: 7
+
+      - name: Upload screenshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots
+          path: e2e/test-results/
+          retention-days: 7
+
+      - name: Fail if tests failed
+        if: steps.e2e.outcome == 'failure'
+        run: exit 1

--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ services/.venv
 
 # Playwright
 /e2e/test-results/
+/e2e/test-results.json
 /e2e/playwright-report/
 /e2e/blob-report/
 /playwright/.cache/

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -6,13 +6,17 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: 1,
-  reporter: [['html', { outputFolder: 'playwright-report' }], ['list']],
+  reporter: [
+    ['html', { outputFolder: 'playwright-report' }],
+    ['json', { outputFile: 'test-results.json' }],
+    ['list'],
+  ],
   outputDir: 'test-results',
 
   use: {
     baseURL: 'http://localhost:5173',
     trace: 'on-first-retry',
-    screenshot: 'only-on-failure',
+    screenshot: 'on',
     permissions: ['clipboard-read', 'clipboard-write'],
   },
 

--- a/scripts/send-e2e-report.mjs
+++ b/scripts/send-e2e-report.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Sends an HTML email report with inline E2E test screenshots via AWS SES.
+ *
+ * Usage (CI only):
+ *   node scripts/send-e2e-report.mjs
+ *
+ * Environment variables:
+ *   SES_SENDER    – verified SES sender email
+ *   SES_RECIPIENT – recipient email
+ *   AWS_REGION    – AWS region (default: eu-west-1)
+ *   GITHUB_SHA    – commit SHA (set by GitHub Actions)
+ *   GITHUB_REF_NAME – branch name (set by GitHub Actions)
+ *   GITHUB_SERVER_URL, GITHUB_REPOSITORY, GITHUB_RUN_ID – for run URL
+ */
+
+import { readFileSync, readdirSync, statSync } from 'node:fs'
+import { join, basename, extname } from 'node:path'
+import { SESClient, SendRawEmailCommand } from '@aws-sdk/client-ses'
+
+const SENDER = process.env.SES_SENDER
+const RECIPIENT = process.env.SES_RECIPIENT || SENDER
+const REGION = process.env.AWS_REGION || 'eu-west-1'
+const RESULTS_JSON = process.env.RESULTS_JSON || 'e2e/test-results.json'
+const SCREENSHOTS_DIR = process.env.SCREENSHOTS_DIR || 'e2e/test-results'
+
+if (!SENDER) {
+  console.error('SES_SENDER env var is required')
+  process.exit(1)
+}
+
+// ---------------------------------------------------------------------------
+// 1. Parse Playwright JSON results
+// ---------------------------------------------------------------------------
+let results
+try {
+  results = JSON.parse(readFileSync(RESULTS_JSON, 'utf-8'))
+} catch (err) {
+  console.error(`Failed to read ${RESULTS_JSON}:`, err.message)
+  process.exit(1)
+}
+
+const suites = results.suites || []
+let totalTests = 0
+let passed = 0
+let failed = 0
+let skipped = 0
+
+function countTests(suite) {
+  for (const spec of suite.specs || []) {
+    for (const test of spec.tests || []) {
+      totalTests++
+      const status = test.status
+      if (status === 'expected') passed++
+      else if (status === 'unexpected') failed++
+      else skipped++
+    }
+  }
+  for (const child of suite.suites || []) {
+    countTests(child)
+  }
+}
+suites.forEach(countTests)
+
+const allPassed = failed === 0
+const statusLabel = allPassed ? 'PASS' : 'FAIL'
+const shortSha = (process.env.GITHUB_SHA || 'local').slice(0, 7)
+const branch = process.env.GITHUB_REF_NAME || 'local'
+const runUrl = process.env.GITHUB_SERVER_URL && process.env.GITHUB_REPOSITORY && process.env.GITHUB_RUN_ID
+  ? `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+  : null
+
+// ---------------------------------------------------------------------------
+// 2. Collect screenshots
+// ---------------------------------------------------------------------------
+function findPngs(dir) {
+  const pngs = []
+  try {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const fullPath = join(dir, entry.name)
+      if (entry.isDirectory()) {
+        pngs.push(...findPngs(fullPath))
+      } else if (extname(entry.name).toLowerCase() === '.png') {
+        pngs.push(fullPath)
+      }
+    }
+  } catch {
+    // directory may not exist
+  }
+  return pngs
+}
+
+const screenshots = findPngs(SCREENSHOTS_DIR)
+console.log(`Found ${screenshots.length} screenshot(s) in ${SCREENSHOTS_DIR}`)
+
+// ---------------------------------------------------------------------------
+// 3. Build MIME email
+// ---------------------------------------------------------------------------
+const boundary = `----=_Part_${Date.now()}`
+const cids = screenshots.map((_, i) => `screenshot-${i}@e2e-report`)
+
+const statusColor = allPassed ? '#22c55e' : '#ef4444'
+const statusEmoji = allPassed ? '&#9989;' : '&#10060;'
+
+let screenshotHtml = ''
+for (let i = 0; i < screenshots.length; i++) {
+  const label = basename(screenshots[i], '.png')
+    .replace(/-/g, ' ')
+    .replace(/\b\w/g, (c) => c.toUpperCase())
+  screenshotHtml += `
+    <div style="margin-bottom:16px;">
+      <p style="font-weight:600;margin:0 0 4px;">${label}</p>
+      <img src="cid:${cids[i]}" style="max-width:100%;border:1px solid #e5e7eb;border-radius:6px;" />
+    </div>`
+}
+
+const htmlBody = `<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,sans-serif;margin:0;padding:0;background:#f9fafb;">
+  <div style="max-width:640px;margin:0 auto;padding:24px;">
+    <div style="background:${statusColor};color:#fff;padding:16px 24px;border-radius:8px 8px 0 0;">
+      <h1 style="margin:0;font-size:20px;">${statusEmoji} PoucherWeb E2E: ${passed}/${totalTests} passed</h1>
+      <p style="margin:4px 0 0;opacity:0.9;font-size:14px;">${branch}@${shortSha}</p>
+    </div>
+    <div style="background:#fff;padding:24px;border:1px solid #e5e7eb;border-top:none;border-radius:0 0 8px 8px;">
+      <table style="width:100%;border-collapse:collapse;margin-bottom:16px;">
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #f3f4f6;font-weight:600;">Passed</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #f3f4f6;color:#22c55e;">${passed}</td>
+        </tr>
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #f3f4f6;font-weight:600;">Failed</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #f3f4f6;color:#ef4444;">${failed}</td>
+        </tr>
+        <tr>
+          <td style="padding:8px 12px;border-bottom:1px solid #f3f4f6;font-weight:600;">Skipped</td>
+          <td style="padding:8px 12px;border-bottom:1px solid #f3f4f6;color:#6b7280;">${skipped}</td>
+        </tr>
+        <tr>
+          <td style="padding:8px 12px;font-weight:600;">Total</td>
+          <td style="padding:8px 12px;">${totalTests}</td>
+        </tr>
+      </table>
+      ${runUrl ? `<p style="margin:0 0 16px;"><a href="${runUrl}" style="color:#2563eb;">View GitHub Actions run &rarr;</a></p>` : ''}
+      ${screenshots.length > 0 ? `<h2 style="font-size:16px;margin:24px 0 12px;">Screenshots</h2>${screenshotHtml}` : '<p style="color:#6b7280;">No screenshots captured.</p>'}
+    </div>
+  </div>
+</body>
+</html>`
+
+const subject = `[${statusLabel}] PoucherWeb E2E: ${passed}/${totalTests} passed (${branch}@${shortSha})`
+
+// Build raw MIME message
+let rawMessage = [
+  `From: ${SENDER}`,
+  `To: ${RECIPIENT}`,
+  `Subject: ${subject}`,
+  'MIME-Version: 1.0',
+  `Content-Type: multipart/related; boundary="${boundary}"`,
+  '',
+  `--${boundary}`,
+  'Content-Type: text/html; charset=UTF-8',
+  'Content-Transfer-Encoding: 7bit',
+  '',
+  htmlBody,
+].join('\r\n')
+
+for (let i = 0; i < screenshots.length; i++) {
+  const data = readFileSync(screenshots[i]).toString('base64')
+  rawMessage += [
+    '',
+    `--${boundary}`,
+    'Content-Type: image/png',
+    'Content-Transfer-Encoding: base64',
+    `Content-ID: <${cids[i]}>`,
+    `Content-Disposition: inline; filename="${basename(screenshots[i])}"`,
+    '',
+    data.match(/.{1,76}/g).join('\r\n'),
+  ].join('\r\n')
+}
+
+rawMessage += `\r\n--${boundary}--\r\n`
+
+// ---------------------------------------------------------------------------
+// 4. Send via SES
+// ---------------------------------------------------------------------------
+const ses = new SESClient({ region: REGION })
+
+try {
+  const result = await ses.send(
+    new SendRawEmailCommand({
+      RawMessage: { Data: Buffer.from(rawMessage) },
+      Source: SENDER,
+      Destinations: [RECIPIENT],
+    })
+  )
+  console.log(`Email sent! MessageId: ${result.MessageId}`)
+} catch (err) {
+  console.error('Failed to send email:', err.message)
+  process.exit(1)
+}

--- a/terraform/environments/prod/main.tf
+++ b/terraform/environments/prod/main.tf
@@ -83,6 +83,14 @@ module "s3" {
   cors_allowed_origins = var.cors_allowed_origins
 }
 
+# SES (E2E Test Report Emails)
+module "ses" {
+  source = "../../modules/ses"
+
+  project_name = var.project_name
+  sender_email = var.ses_sender_email
+}
+
 # Lambda
 module "lambda" {
   source = "../../modules/lambda"

--- a/terraform/environments/prod/outputs.tf
+++ b/terraform/environments/prod/outputs.tf
@@ -38,6 +38,16 @@ output "db_secret_arn" {
   value       = module.rds.db_password_secret_arn
 }
 
+output "ses_sender_email_arn" {
+  description = "ARN of the SES verified email identity"
+  value       = module.ses.sender_email_arn
+}
+
+output "ses_send_policy_arn" {
+  description = "ARN of the IAM policy for sending SES emails"
+  value       = module.ses.ses_send_policy_arn
+}
+
 output "screenshots_bucket" {
   description = "Screenshots S3 bucket name"
   value       = module.s3.bucket_id

--- a/terraform/environments/prod/terraform.tfvars
+++ b/terraform/environments/prod/terraform.tfvars
@@ -24,6 +24,9 @@ cognito_logout_urls = [
   # Add production URL: "https://yourdomain.com"
 ]
 
+# SES
+ses_sender_email = "craig@craigmacintyre.co.uk"
+
 # Lambda
 lambda_package_path = "../../../services/lambda.zip"
 

--- a/terraform/environments/prod/variables.tf
+++ b/terraform/environments/prod/variables.tf
@@ -55,6 +55,13 @@ variable "cognito_domain" {
   default     = ""
 }
 
+# SES
+variable "ses_sender_email" {
+  description = "Email address for sending E2E test reports (must be verified in SES)"
+  type        = string
+  default     = "craig@craigmacintyre.co.uk"
+}
+
 # Lambda
 variable "lambda_package_path" {
   description = "Path to Lambda deployment package"

--- a/terraform/modules/ses/main.tf
+++ b/terraform/modules/ses/main.tf
@@ -1,0 +1,27 @@
+# SES Module
+# Creates SES email identity for sending E2E test report emails
+
+resource "aws_ses_email_identity" "sender" {
+  email = var.sender_email
+}
+
+# IAM policy for sending emails via SES
+resource "aws_iam_policy" "ses_send" {
+  name        = "${var.project_name}-ses-send-email"
+  description = "Allow sending emails via SES for E2E test reports"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid    = "AllowSendEmail"
+        Effect = "Allow"
+        Action = [
+          "ses:SendRawEmail",
+          "ses:SendEmail"
+        ]
+        Resource = aws_ses_email_identity.sender.arn
+      }
+    ]
+  })
+}

--- a/terraform/modules/ses/outputs.tf
+++ b/terraform/modules/ses/outputs.tf
@@ -1,0 +1,9 @@
+output "sender_email_arn" {
+  description = "ARN of the verified SES email identity"
+  value       = aws_ses_email_identity.sender.arn
+}
+
+output "ses_send_policy_arn" {
+  description = "ARN of the IAM policy for sending emails"
+  value       = aws_iam_policy.ses_send.arn
+}

--- a/terraform/modules/ses/variables.tf
+++ b/terraform/modules/ses/variables.tf
@@ -1,0 +1,9 @@
+variable "project_name" {
+  description = "Project name for resource naming"
+  type        = string
+}
+
+variable "sender_email" {
+  description = "Email address to verify and use as sender/recipient for E2E reports"
+  type        = string
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,5 +1,5 @@
 /// <reference types="vitest" />
-/// <reference types="vite/client" />import { defineConfig } from 'vite'
+/// <reference types="vite/client" />
 
 import { defineConfig } from 'vite'
 import { VitePluginFonts } from 'vite-plugin-fonts'
@@ -25,6 +25,7 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
-    css: true
+    css: true,
+    exclude: ['e2e/**', 'node_modules/**']
   }
 })


### PR DESCRIPTION
## Summary
- Captures screenshots for all Playwright E2E tests (pass and fail)
- Sends an HTML email report with inline screenshots via AWS SES after CI runs
- Terraform SES module creates email identity + scoped IAM policy
- GitHub Actions workflow runs tests, sends email, uploads artifacts

## Post-merge steps
1. Email already verified in SES (`craig@craigmacintyre.co.uk`)
2. IAM user already has SES permissions
3. Trigger `workflow_dispatch` to test the full CI flow

## Test plan
- [x] All 67 unit tests pass
- [x] All 6 E2E tests pass with screenshots captured
- [x] JSON report generated at e2e/test-results.json
- [x] Test email sent successfully via SES

🤖 Generated with [Claude Code](https://claude.com/claude-code)