### PR TITLE
Add user settings with dark mode and display name

### DIFF
--- a/services/migrations/003_add_user_preferences.sql
+++ b/services/migrations/003_add_user_preferences.sql
@@ -1,0 +1,3 @@
+-- Add preferences JSONB column to users table
+-- Stores user settings like theme and display name
+ALTER TABLE users ADD COLUMN preferences JSONB DEFAULT '{}'::jsonb NOT NULL;

--- a/services/shared/db/models.py
+++ b/services/shared/db/models.py
@@ -1,6 +1,6 @@
 import uuid
 from datetime import datetime, timezone
-from sqlalchemy import Column, String, Text, ForeignKey, DateTime, UniqueConstraint
+from sqlalchemy import Column, String, Text, ForeignKey, DateTime, UniqueConstraint, text
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 from sqlalchemy.orm import declarative_base, relationship
 
@@ -19,6 +19,7 @@ class User(Base):
     email = Column(String(255), unique=True, nullable=False)
     name = Column(String(255), nullable=False)
     picture_url = Column(Text, nullable=True)
+    preferences = Column(JSONB, nullable=False, default=dict, server_default=text("'{}'::jsonb"))
     created_at = Column(DateTime(timezone=True), default=utc_now)
     updated_at = Column(DateTime(timezone=True), default=utc_now, onupdate=utc_now)
 
@@ -32,6 +33,7 @@ class User(Base):
             "email": self.email,
             "name": self.name,
             "picture": self.picture_url,
+            "preferences": self.preferences or {},
         }
 
 

--- a/services/users/handler.py
+++ b/services/users/handler.py
@@ -93,6 +93,12 @@ def update(event, context, user_id: str):
             if "picture" in body:
                 auth_user.picture_url = body["picture"]
 
+            if "preferences" in body and isinstance(body["preferences"], dict):
+                # Merge new preferences into existing ones
+                current_prefs = auth_user.preferences or {}
+                current_prefs.update(body["preferences"])
+                auth_user.preferences = current_prefs
+
             return success({"user": auth_user.to_dict()})
 
     except Exception as e:

--- a/src/api/types.ts
+++ b/src/api/types.ts
@@ -1,7 +1,13 @@
+export interface UserPreferences {
+  theme?: 'light' | 'dark'
+  displayName?: string
+}
+
 export interface User {
   id: string
   email: string
   name: string
+  preferences?: UserPreferences
 }
 
 export interface Bookmark {

--- a/src/components/AdminScreen/AdminScreen.tsx
+++ b/src/components/AdminScreen/AdminScreen.tsx
@@ -8,7 +8,7 @@ import { Tags } from '../Tags'
 import { Pagination } from '../Pagination'
 import { Profile } from '../Profile'
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
-import { faBars } from '@fortawesome/free-solid-svg-icons'
+import { faBars, faGear } from '@fortawesome/free-solid-svg-icons'
 import { Loader } from '../Loader/Loader'
 import { Search } from '../Search'
 import { Modal } from '../Modal'
@@ -16,12 +16,15 @@ import { UserProvider } from '../../contexts/user-context'
 import { Drawer } from '../ui/drawer'
 import { Button } from '../ui/button'
 import { ThemeToggle } from '../ThemeToggle'
+import { Settings } from '../Settings'
+import { useModalStore } from '../../store/modal-store'
 
 export type { CognitoAuthUser }
 
 export const AdminScreen = () => {
   const { user, isAuthenticated, isLoading } = useCognitoAuth()
   const [drawerOpen, setDrawerOpen] = useState(false)
+  const { openModal, setModalContent } = useModalStore()
 
   if (isLoading) return <Loader />
 
@@ -45,7 +48,18 @@ export const AdminScreen = () => {
                   </>
                 )}
 
-                <div className="p-4 mt-auto border-t border-gray-200 dark:border-gray-700">
+                <div className="p-4 mt-auto border-t border-gray-200 dark:border-gray-700 space-y-2">
+                  <Button
+                    variant="ghost"
+                    className="w-full justify-start gap-2 text-foreground-muted dark:text-gray-400 hover:text-foreground dark:hover:text-gray-100"
+                    onClick={() => {
+                      setModalContent(<Settings />)
+                      openModal()
+                    }}
+                  >
+                    <FontAwesomeIcon icon={faGear} />
+                    Settings
+                  </Button>
                   <LogoutButton />
                 </div>
               </div>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,0 +1,108 @@
+import { useState } from 'react'
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
+import { faMoon, faSun } from '@fortawesome/free-solid-svg-icons'
+import { usePreferencesStore } from '../../store/preferences-store'
+import { useUser } from '../../contexts/user-context'
+import { useUpdateUser } from '../../api/hooks'
+import { useModalStore } from '../../store/modal-store'
+import { Button } from '../ui/button'
+import { Input } from '../ui/input'
+
+export const Settings = () => {
+  const { theme, toggleTheme, displayName, setDisplayName } = usePreferencesStore()
+  const { data } = useUser()
+  const updateUser = useUpdateUser()
+  const closeModal = useModalStore((s) => s.closeModal)
+
+  const [nameInput, setNameInput] = useState(displayName)
+  const [saved, setSaved] = useState(false)
+
+  const handleSaveDisplayName = () => {
+    setDisplayName(nameInput)
+    if (data?.user.id) {
+      updateUser.mutate({
+        id: data.user.id,
+        updates: { preferences: { displayName: nameInput } }
+      })
+    }
+    setSaved(true)
+    setTimeout(() => setSaved(false), 2000)
+  }
+
+  const handleToggleTheme = () => {
+    toggleTheme()
+    const newTheme = theme === 'light' ? 'dark' : 'light'
+    if (data?.user.id) {
+      updateUser.mutate({
+        id: data.user.id,
+        updates: { preferences: { theme: newTheme } }
+      })
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <h2 className="text-lg font-semibold text-foreground dark:text-gray-100">
+        Settings
+      </h2>
+
+      {/* Dark Mode Toggle */}
+      <div className="flex items-center justify-between">
+        <div>
+          <p className="font-medium text-foreground dark:text-gray-100">Dark Mode</p>
+          <p className="text-sm text-foreground-muted dark:text-gray-400">
+            Toggle between light and dark theme
+          </p>
+        </div>
+        <button
+          onClick={handleToggleTheme}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+            theme === 'dark' ? 'bg-forest-600' : 'bg-gray-300 dark:bg-gray-600'
+          }`}
+          aria-label={theme === 'light' ? 'Switch to dark mode' : 'Switch to light mode'}
+        >
+          <span
+            className={`inline-flex h-4 w-4 items-center justify-center rounded-full bg-white transition-transform ${
+              theme === 'dark' ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          >
+            <FontAwesomeIcon
+              icon={theme === 'dark' ? faMoon : faSun}
+              className="h-2.5 w-2.5 text-gray-600"
+            />
+          </span>
+        </button>
+      </div>
+
+      {/* Display Name */}
+      <div className="space-y-2">
+        <div>
+          <p className="font-medium text-foreground dark:text-gray-100">Display Name</p>
+          <p className="text-sm text-foreground-muted dark:text-gray-400">
+            How your name appears in the app
+          </p>
+        </div>
+        <div className="flex gap-2">
+          <Input
+            value={nameInput}
+            onChange={(e) => setNameInput(e.target.value)}
+            placeholder="Enter display name"
+          />
+          <Button
+            onClick={handleSaveDisplayName}
+            disabled={!nameInput.trim() || nameInput === displayName}
+          >
+            {saved ? 'Saved!' : 'Save'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Close button */}
+      <div className="flex justify-end pt-2 border-t border-gray-200 dark:border-gray-700">
+        <Button variant="outline" onClick={closeModal}>
+          Close
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/Settings/index.ts
+++ b/src/components/Settings/index.ts
@@ -1,0 +1,1 @@
+export { Settings } from './Settings'

--- a/src/components/ThemeToggle/ThemeToggle.tsx
+++ b/src/components/ThemeToggle/ThemeToggle.tsx
@@ -1,10 +1,10 @@
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { faSun, faMoon } from '@fortawesome/free-solid-svg-icons'
-import { useThemeStore } from '../../store/theme-store'
+import { usePreferencesStore } from '../../store/preferences-store'
 import { Button } from '../ui/button'
 
 export const ThemeToggle = () => {
-  const { theme, toggleTheme } = useThemeStore()
+  const { theme, toggleTheme } = usePreferencesStore()
 
   return (
     <Button

--- a/src/contexts/user-context.tsx
+++ b/src/contexts/user-context.tsx
@@ -1,6 +1,7 @@
-import { useContext, createContext, ReactNode } from 'react'
+import { useContext, createContext, useEffect, ReactNode } from 'react'
 import { useCognitoAuth } from './auth-context'
 import { useUserInit } from '../api/hooks'
+import { usePreferencesStore } from '../store/preferences-store'
 import type { User, Tag } from '../api/types'
 
 interface UserProviderProps {
@@ -41,7 +42,13 @@ export const UserProvider = ({ children }: UserProviderProps) => {
     name: user?.name
   })
 
-  console.log('data: ', data)
+  const hydrateFromBackend = usePreferencesStore((s) => s.hydrateFromBackend)
+
+  useEffect(() => {
+    if (data?.user?.preferences) {
+      hydrateFromBackend(data.user.preferences)
+    }
+  }, [data?.user?.preferences, hydrateFromBackend])
 
   const value: UserContextProps = {
     loading: isLoading,

--- a/src/store/preferences-store.ts
+++ b/src/store/preferences-store.ts
@@ -1,0 +1,67 @@
+import create from 'zustand'
+import { persist } from 'zustand/middleware'
+import type { UserPreferences } from '../api/types'
+
+type Theme = 'light' | 'dark'
+
+interface PreferencesState {
+  theme: Theme
+  displayName: string
+  setTheme: (theme: Theme) => void
+  toggleTheme: () => void
+  setDisplayName: (name: string) => void
+  hydrateFromBackend: (prefs: UserPreferences | undefined) => void
+}
+
+function applyTheme(theme: Theme) {
+  const root = document.documentElement
+  if (theme === 'dark') {
+    root.classList.add('dark')
+  } else {
+    root.classList.remove('dark')
+  }
+}
+
+const usePreferencesStore = create<PreferencesState>()(
+  persist(
+    (set, get) => ({
+      theme: 'light',
+      displayName: '',
+      setTheme: (theme) => {
+        set({ theme })
+        applyTheme(theme)
+      },
+      toggleTheme: () => {
+        const newTheme = get().theme === 'light' ? 'dark' : 'light'
+        set({ theme: newTheme })
+        applyTheme(newTheme)
+      },
+      setDisplayName: (displayName) => {
+        set({ displayName })
+      },
+      hydrateFromBackend: (prefs) => {
+        if (!prefs) return
+        const updates: Partial<PreferencesState> = {}
+        if (prefs.theme) {
+          updates.theme = prefs.theme
+          applyTheme(prefs.theme)
+        }
+        if (prefs.displayName) {
+          updates.displayName = prefs.displayName
+        }
+        set(updates)
+      },
+    }),
+    {
+      name: 'user-preferences',
+      onRehydrateStorage: () => (state) => {
+        if (state) {
+          applyTheme(state.theme)
+        }
+      },
+    }
+  )
+)
+
+export { usePreferencesStore }
+export type { Theme }


### PR DESCRIPTION
## Summary
- Adds a **Settings modal** accessible from a gear icon in the sidebar
- **Dark mode toggle** with a styled switch that syncs preference to backend
- **Display name** input field with save button
- **Zustand preferences store** with `localStorage` persistence for instant local state
- **Backend JSONB column** (`preferences`) on users table with partial merge updates
- **Hydrates preferences from backend** on login for cross-device sync

## Changes
### Backend
- `services/migrations/003_add_user_preferences.sql` — adds `preferences JSONB` column
- `services/shared/db/models.py` — adds preferences field + `to_dict()` serialization
- `services/users/handler.py` — merges incoming preferences in PUT handler

### Frontend
- `src/api/types.ts` — `UserPreferences` interface
- `src/store/preferences-store.ts` — Zustand store with persist middleware
- `src/components/Settings/Settings.tsx` — Settings modal UI
- `src/components/AdminScreen/AdminScreen.tsx` — gear icon in sidebar
- `src/components/ThemeToggle/ThemeToggle.tsx` — uses unified preferences store
- `src/contexts/user-context.tsx` — hydrates preferences from backend on init

## Test plan
- [x] All 67 unit tests pass
- [ ] Verify gear icon appears in sidebar and opens Settings modal
- [ ] Toggle dark mode and confirm it persists across page reload
- [ ] Set display name, refresh, confirm it persists
- [ ] Verify preferences sync to backend (check DB)

🤖 Generated with [Claude Code](https://claude.ai/code)